### PR TITLE
Download missing C dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext):
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+                      '-DPYTHON_EXECUTABLE=' + sys.executable,
+                      '-DRP_ENABLE_DOWNLOADING=on']
 
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]


### PR DESCRIPTION
This PR addresses issue #1 

This change makes sure that `libnest2d` will download any missing C dependencies (I was unable to install nest2D without this change)

Thanks for the library, BTW! I searched for a while for a python-based nesting library and was very happy to finally find this.