### PR TITLE
add area, translation and rotation attrs to Item

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,9 @@ PYBIND11_MODULE(nest2D, m)
     // see lib/libnest2d/include/libnest2d/nester.hpp
     py::class_<Item>(m, "Item", "An item to be placed on a bin.")
         .def(py::init<std::vector<Point>>())
+        .def_property_readonly("area", [](const Item &i) { return i.area(); })
+        .def_property_readonly("translation", [](const Item &i) { return i.translation(); })
+        .def_property_readonly("rotation", [](const Item &i) { return (double) i.rotation(); })
         .def("__repr__",
              [](const Item &i) {
                  std::string r("Item(area: ");


### PR DESCRIPTION
This adds `translation`, `rotation` and `area` attributes to the `Item` class. As I mentioned in #3, this may help with applying textures or image overlays to transformed features.

The returned rotation is in radians. The returned translation is a `Point` that can be interpreted as a vector.

An example:
```python
import nest2D as n2d
item = n2d.Item([n2d.Point(10, 10), n2d.Point(10, 12), n2d.Point(12, 12), n2d.Point(10, 10)])
packing = n2d.nest([item] * 10, n2d.Box(100, 100))

[p.rotation for p in packing[0]]
# [0.0, 3.141592653589793, 0.0, 1.5707963267948966, 3.141592653589793, 0.0, ...]

[p.translation for p in packing[0]]
# [Point(39, 39), Point(61, 60), Point(38, 40), Point(60, 38), Point(62, 59),  ...]
